### PR TITLE
FAI-21614: bump serialize-javascript and form-data to fix dependabot CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5674,16 +5674,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -6114,9 +6114,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -8516,15 +8516,6 @@
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -9319,12 +9310,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/set-function-length": {

--- a/package.json
+++ b/package.json
@@ -151,7 +151,8 @@
     "react-dom": "^18.3.1"
   },
   "overrides": {
-    "form-data": "4.0.5",
+    "form-data": "^4.0.6",
+    "serialize-javascript": "^7.0.5",
     "tar-fs": "^3.1.1",
     "@isaacs/brace-expansion": "5.0.1",
     "lodash": "4.17.23",


### PR DESCRIPTION
## [FAI-21614](https://faros-ai.atlassian.net/browse/FAI-21614) — dependabot vulnerability fixes

| Package | From | To | CVE | Dependabot | Source |
| --- | --- | --- | --- | --- | --- |
| serialize-javascript | 6.0.2 | ^7.0.5 | CVE-2026-34043 (also GHSA-5c6j-r48x-rmvq) | #93 | description |
| form-data | 4.0.5 | ^4.0.6 | CVE-2026-12143 | #98 | comment |

`serialize-javascript@7.0.5` remains CommonJS-compatible for its build-time consumers (copy-webpack-plugin, mocha) and requires node >=20. Transitive `hasown` bumped 2.0.2 -> 2.0.4 (required by form-data@4.0.6); `randombytes` pruned (dropped by serialize-javascript v7).

The other two CVEs listed on this ticket need no change here: `qs` is already at the patched 6.15.2 on `main`, and `uuid` is not present in the dependency tree.

**Verification:** `npm run compile` (webpack production, exercises serialize-javascript via copy-webpack-plugin), `compile-tests` (tsc), and `lint` all pass. The full `vscode-test` integration run requires a headless VS Code instance and was not executed locally.

Generated with [Claude Code](https://claude.com/claude-code)


[FAI-21614]: https://faros-ai.atlassian.net/browse/FAI-21614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ