### PR TITLE
FAI-21614: release faros-vscode-extension 0.1.17 (ship vuln fixes)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "faros-vscode-extension",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "faros-vscode-extension",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "dependencies": {
         "@chakra-ui/react": "^2.10.3",
         "@emotion/react": "^11.13.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "faros-vscode-extension",
   "displayName": "Faros AI",
   "description": "Faros AI's Visual Studio Code extension",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "publisher": "farosai",
   "icon": "images/logo.png",
   "engines": {


### PR DESCRIPTION
## Release 0.1.17 — [FAI-21614](https://faros-ai.atlassian.net/browse/FAI-21614)

Version bump to publish the already-merged dependency-vulnerability fixes (PR #51) to the VS Code Marketplace:
- serialize-javascript 6.0.2 → 7.0.5 (CVE-2026-34043)
- form-data 4.0.5 → 4.0.6 (CVE-2026-12143)

Bump only (`package.json` + `package-lock.json` version). After merge, creating a GitHub Release tagged `0.1.17` triggers the Marketplace publish.

Generated with [Claude Code](https://claude.com/claude-code)

[FAI-21614]: https://faros-ai.atlassian.net/browse/FAI-21614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ